### PR TITLE
fix: the splitlines would incorrectly trim the char #8230 and #8240

### DIFF
--- a/models/convert-to-ggml.py
+++ b/models/convert-to-ggml.py
@@ -43,7 +43,7 @@ with open(model_dir / 'config.json', 'r', encoding='utf-8') as f:
     hparams = json.load(f)
 
 with open(model_dir / 'vocab.txt', 'r', encoding='utf-8') as f:
-    vocab = f.read().splitlines()
+    vocab = [line.rstrip('\n') for line in f.readlines()]
 
 # load tokenizer and model
 tokenizer = AutoTokenizer.from_pretrained(model_dir)


### PR DESCRIPTION
Use `bge-large-zh-v1.5` which includes the `#8230` and `#8240` character to test.

BTW: please merge the test program from @xyzhang626 for better testing.